### PR TITLE
remove references to reverification

### DIFF
--- a/queue.py
+++ b/queue.py
@@ -67,7 +67,7 @@ class CertificateGeneration(object):
         self.whitelist = CertificateWhitelist.objects.all()
         self.restricted = UserProfile.objects.filter(allow_certificate=False)
         self.api_key = api_key
-        
+
 
     def add_cert(self, student, course_id, defined_status="downloadable", course=None, forced_grade=None, template_file=None, title='None'):
         """
@@ -131,7 +131,7 @@ class CertificateGeneration(object):
                        break
                 except:
                     print "this course don't have " +section_key
-              
+
             if not description:
                description = "course_description"
 
@@ -141,11 +141,10 @@ class CertificateGeneration(object):
             enrollment_mode, __ = CourseEnrollment.enrollment_mode_for_user(student, course_id)
             mode_is_verified = (enrollment_mode == GeneratedCertificate.MODES.verified)
             user_is_verified = SoftwareSecurePhotoVerification.user_is_verified(student)
-            user_is_reverified = SoftwareSecurePhotoVerification.user_is_reverified_for_all(course_id, student)
             cert_mode = enrollment_mode
-            if (mode_is_verified and not (user_is_verified and user_is_reverified)):
+            if (mode_is_verified and not (user_is_verified)):
                 cert_mode = GeneratedCertificate.MODES.honor
-            
+
             if forced_grade:
                 grade['grade'] = forced_grade
 
@@ -218,9 +217,9 @@ class CertificateGeneration(object):
                             }
                     payload = json.dumps(payload)
                     r = requests.post('https://api.accredible.com/v1/credentials', payload, headers={'Authorization':'Token token=' + self.api_key, 'Content-Type':'application/json'})
-                    
+
                     if r.status_code == 200:
-                       json_response = r.json()  
+                       json_response = r.json()
                        cert.status = defined_status
                        cert.key = json_response["credential"]["id"]
                        if 'private' in json_response:
@@ -230,7 +229,7 @@ class CertificateGeneration(object):
                        cert.save()
                     else:
                         new_status = "errors"
-                    
+
 
             else:
                 cert_status = status.notpassing
@@ -238,6 +237,3 @@ class CertificateGeneration(object):
                 cert.save()
 
         return new_status
-
-
-


### PR DESCRIPTION
In reference to #1 - note, I'm not currently running an up-to-date version of EdX, so this should be tested.  It looks like a number of changes have been made to queue.py since this was implemented by Accredible.

Reverification was removed in [this commit from edx/edx-platform](https://github.com/edx/edx-platform/commit/d0df6266858d4cec5f457372c23c633276dcfc3c#diff-2953c01c7491c70c467704320a959bbdL248). 

I'd also suggest taking a look at the [most up-to-date version of the queue.py file](https://github.com/edx/edx-platform/blob/76b8e2e89761c30ac7aa2fa5e8aca4dc35d9002b/lms/djangoapps/certificates/queue.py) for additional updates that may need to be made here before it is fully up to date.

Happy to work on this with you if it will be helpful, but again, I'm not on a recent version of EdX (Gymnasium will be moving to Dogwood in the next month or two).

cc: @aurishAtKnysys
:+1: 